### PR TITLE
remove mime-types

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,0 @@
-gem 'mime-types'


### PR DESCRIPTION
Redmine 3.2.2で`bundle install`時にエラーが発生。
`mime-types`が重複してしまう模様。
