### PR TITLE
Remove obsolete link name (reported by takaxp)

### DIFF
--- a/app/views/gantts/3.x/show.html.erb
+++ b/app/views/gantts/3.x/show.html.erb
@@ -333,14 +333,14 @@
 <table style="width:100%">
 <tr>
   <td style="text-align:left;">
-    <%= link_to_content_update("\xc2\xab " + l(:label_previous),
-                               params.merge(@gantt.params_previous),
-                               :accesskey => accesskey(:previous)) %>
+    <%= link_to("\xc2\xab " + l(:label_previous),
+                {:params => params.merge(@gantt.params_previous)},
+                :accesskey => accesskey(:previous)) %>
   </td>
   <td style="text-align:right;">
-    <%= link_to_content_update(l(:label_next) + " \xc2\xbb",
-                               params.merge(@gantt.params_next),
-                               :accesskey => accesskey(:next)) %>
+    <%= link_to(l(:label_next) + " \xc2\xbb",
+                {:params => params.merge(@gantt.params_next)},
+                :accesskey => accesskey(:next)) %>
   </td>
 </tr>
 </table>


### PR DESCRIPTION
Current PR is a fix for Issue #14 .

Redmine-3.4.x silently removed _link_to_content_update_ method from all sources. In fact even before that, the method was just a wrapper around the _link_to_ method (in all Redmine versions, back to 3.1.1):

```ruby
# redmine : app/helpers/application_helper.rb
def link_to_content_update(text, url_params = {}, html_options = {})
  link_to(text, url_params, html_options)
end
```

So I think the proposed by _takaxp_ changes are legit and safe to be done. Tested the result with _redmine -3.3.2_ and _redmine-3.4.0_ - working without problems.