### PR TITLE
管理メニューのスタイリングを調整

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -18,5 +18,8 @@ Redmine::Plugin.register :redmine_work_days do
   version '1.3.0'
   author_url 'http://agileware.jp'
 
-  menu :admin_menu, :rest_days, { :controller => 'rest_days', :action => 'index' }, :caption => :rest_days
+  menu :admin_menu, :rest_days,
+  { :controller => 'rest_days', :action => 'index' },
+  :caption => :rest_days,
+  :html => { :class => 'icon icon-rest-days'}
 end


### PR DESCRIPTION
テーマによっては、管理メニューの表示部分が崩れるため、
管理メニュー部分のclassの指定を追加しました。
